### PR TITLE
[uuid-generation] Add generateUUID to PBXProj

### DIFF
--- a/Sources/xcodeproj/PBXProj.swift
+++ b/Sources/xcodeproj/PBXProj.swift
@@ -3,6 +3,7 @@ import Unbox
 import PathKit
 import xcodeprojprotocols
 import xcodeprojextensions
+import CryptoSwift
 
 /// It represents a .pbxproj file
 public struct PBXProj {
@@ -271,6 +272,28 @@ extension PBXProj {
                        rootObject: rootObject,
                        classes: classes,
                        objects: objects)
+    }
+    
+}
+
+// MARK: - PBXProj Extension (UUID Generation)
+
+public extension PBXProj {
+
+    /// Returns a valid UUID for new elements.
+    ///
+    /// - Parameter element: project element class.
+    /// - Returns: UUID available to be used.
+    public func generateUUID<T: ProjectElement>(for element: T.Type) -> UUID {
+        var uuid: UUID = ""
+        var counter: UInt = 0
+        let random: String = String.random()
+        let className: String = String(describing: T.self)
+        repeat {
+            counter += 1
+           uuid = String(format: "%08X%08X%08X", className, random, counter)
+        } while(self.objects.map({$0.reference}).contains(uuid))
+        return uuid
     }
     
 }

--- a/Sources/xcodeprojextensions/String+Extras.swift
+++ b/Sources/xcodeprojextensions/String+Extras.swift
@@ -6,4 +6,15 @@ extension String {
         return "\"\(self)\""
     }
     
+    public static func random(length: Int = 20) -> String {
+        let base = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        var randomString: String = ""
+        
+        for _ in 0..<length {
+            let randomValue = arc4random_uniform(UInt32(base.characters.count))
+            randomString += "\(base[base.index(base.startIndex, offsetBy: Int(randomValue))])"
+        }
+        return randomString
+    }
+    
 }


### PR DESCRIPTION
**Issue:** [Link](https://github.com/carambalabs/xcodeproj/issues/10)

### Short description
Support UUID generation from `PBXProj`

### Solution
Add a method that generates a random identifier and checks that the UUID doesn't already exist in the project.

### GIF
![gif](https://media.giphy.com/media/nXxOjZrbnbRxS/giphy.gif)