### PR TITLE
Convert booleans to YES and NO

### DIFF
--- a/Sources/xcodeproj/PBXProjWriter.swift
+++ b/Sources/xcodeproj/PBXProjWriter.swift
@@ -95,6 +95,12 @@ class PBXProjWriter {
             }
         }
 
+        if string == "false" {
+            string = "NO"
+        } else if string == "true" {
+            string = "YES"
+        }
+
         write(string: string)
         if let comment = commentedString.comment {
             write(string: " ")


### PR DESCRIPTION
This fixes cases where build settings contain booleans instead of YES and NO, and writes them properly so Xcode can read them