### PR TITLE
String escaping

### DIFF
--- a/Sources/CommentedString.swift
+++ b/Sources/CommentedString.swift
@@ -18,6 +18,35 @@ struct CommentedString {
         self.string = string
         self.comment = comment
     }
+
+    private static let invalidCharacters = CharacterSet.alphanumerics.inverted
+        .subtracting(CharacterSet(charactersIn: "_./"))
+
+    var validString: String {
+        switch string {
+            case "": return "".quoted
+            case "false": return "NO"
+            case "true": return "YES"
+            default: break
+        }
+
+        var escaped = string
+        // escape newlines
+        escaped = escaped.replacingOccurrences(of: "\n", with: "\\n")
+
+        // escape quotes
+        var range: Range<String.Index>?
+        if escaped.isQuoted {
+            range = escaped.index(after: escaped.startIndex)..<escaped.index(before: escaped.endIndex)
+        }
+        escaped = escaped.replacingOccurrences(of: "([^\\\\])(\")", with: "$1\\\\$2", options: .regularExpression, range: range)
+
+        if !escaped.isQuoted && escaped.rangeOfCharacter(from: CommentedString.invalidCharacters) != nil {
+            escaped = escaped.quoted
+        }
+
+        return escaped
+    }
     
 }
 

--- a/Sources/PBXProjWriter.swift
+++ b/Sources/PBXProjWriter.swift
@@ -16,7 +16,6 @@ class PBXProjWriter {
     var indent: UInt = 0
     var output: String = ""
     var multiline: Bool = true
-    let invalidCharacters = CharacterSet.alphanumerics.inverted.subtracting(CharacterSet(charactersIn: "_./"))
 
     func write(proj: PBXProj) -> String {
         writeUtf8()
@@ -85,30 +84,7 @@ class PBXProjWriter {
     }
     
     private func write(commentedString: CommentedString) {
-        var string = commentedString.string
-
-        // escape newlines
-        string = string.replacingOccurrences(of: "\n", with: "\\n")
-
-        // escape quotes
-        if string.isQuoted {
-            let range = string.index(after: string.startIndex)..<string.index(before: string.endIndex)
-            string = string.replacingOccurrences(of: "\"", with: "\\\"", options: [], range: range)
-        } else {
-            string = string.replacingOccurrences(of: "\"", with: "\\\"")
-        }
-
-        if string.isEmpty || (!string.isQuoted && string.rangeOfCharacter(from: invalidCharacters) != nil) {
-            string = string.quoted
-        }
-
-        if string == "false" {
-            string = "NO"
-        } else if string == "true" {
-            string = "YES"
-        }
-
-        write(string: string)
+        write(string: commentedString.validString)
         if let comment = commentedString.comment {
             write(string: " ")
             write(comment: comment)

--- a/Sources/PBXProjWriter.swift
+++ b/Sources/PBXProjWriter.swift
@@ -87,6 +87,17 @@ class PBXProjWriter {
     private func write(commentedString: CommentedString) {
         var string = commentedString.string
 
+        // escape newlines
+        string = string.replacingOccurrences(of: "\n", with: "\\n")
+
+        // escape quotes
+        if string.isQuoted {
+            let range = string.index(after: string.startIndex)..<string.index(before: string.endIndex)
+            string = string.replacingOccurrences(of: "\"", with: "\\\"", options: [], range: range)
+        } else {
+            string = string.replacingOccurrences(of: "\"", with: "\\\"")
+        }
+
         if string.isEmpty || (!string.isQuoted && string.rangeOfCharacter(from: invalidCharacters) != nil) {
             string = string.quoted
         }

--- a/Sources/PBXProjWriter.swift
+++ b/Sources/PBXProjWriter.swift
@@ -16,9 +16,8 @@ class PBXProjWriter {
     var indent: UInt = 0
     var output: String = ""
     var multiline: Bool = true
-    // swiftlint:disable next force_try legacy_constructor
-    let quotesRequireRegEx = try! NSRegularExpression(pattern: "[<>;&${}\\+\\-=, ]", options: [])
-    
+    let invalidCharacters = CharacterSet.alphanumerics.inverted.subtracting(CharacterSet(charactersIn: "_./"))
+
     func write(proj: PBXProj) -> String {
         writeUtf8()
         writeNewLine()
@@ -88,11 +87,8 @@ class PBXProjWriter {
     private func write(commentedString: CommentedString) {
         var string = commentedString.string
 
-        if !string.isQuoted {
-            let stringRange = NSRange(location: 0, length: string.characters.count)
-            if string.isEmpty || quotesRequireRegEx.firstMatch(in: string, options: [], range: stringRange) != nil {
-                string = string.quoted
-            }
+        if string.isEmpty || (!string.isQuoted && string.rangeOfCharacter(from: invalidCharacters) != nil) {
+            string = string.quoted
         }
 
         if string == "false" {

--- a/Tests/xcodeprojTests/PBXProjWriterSpecs.swift
+++ b/Tests/xcodeprojTests/PBXProjWriterSpecs.swift
@@ -31,5 +31,50 @@ class PBXProjWriterSpecs: XCTestCase {
         XCTAssertEqual(plist.array?[2], .dictionary([CommentedString("d"): .string(CommentedString("e"))]))
     }
 
+    func test_commentedStringEscaping() {
+
+        let quote = "\""
+        let escapedNewline = "\\n"
+        let escapedQuote = "\\\""
+
+        let values: [String: String] = [
+            "a": "a",
+            "a".quoted: "a".quoted,
+            "@": "@".quoted,
+            "[": "[".quoted,
+            "<": "<".quoted,
+            ">": ">".quoted,
+            ";": ";".quoted,
+            "&": "&".quoted,
+            "$": "$".quoted,
+            "{": "{".quoted,
+            "}": "}".quoted,
+            "\\": "\\".quoted,
+            "+": "+".quoted,
+            "-": "-".quoted,
+            "=": "=".quoted,
+            ",": ",".quoted,
+            " ": " ".quoted,
+            "a;": "a;".quoted,
+            "a_a": "a_a",
+            "a a": "a a".quoted,
+            "": "".quoted,
+            "a\(quote)q\(quote)a": "a\(escapedQuote)q\(escapedQuote)a".quoted,
+            "a\(quote)q\(quote)a".quoted: "a\(escapedQuote)q\(escapedQuote)a".quoted,
+            "a\(escapedQuote)a\(escapedQuote)": "a\(escapedQuote)a\(escapedQuote)".quoted,
+            "a\na": "a\\na".quoted,
+            "\n": escapedNewline.quoted,
+            "\na": "\(escapedNewline)a".quoted,
+            "a\n": "a\(escapedNewline)".quoted,
+            "a\na".quoted: "a\(escapedNewline)a".quoted,
+            "a\(escapedNewline)a": "a\(escapedNewline)a".quoted,
+            "a\(escapedNewline)a".quoted: "a\(escapedNewline)a".quoted,
+        ]
+
+        for (initial, expected) in values {
+            let escapedString = CommentedString(initial).validString
+            XCTAssertEqual(escapedString, expected)
+        }
+    }
 
 }


### PR DESCRIPTION
This changes whether a string is quoted when written from a blacklist to a whitelist. This makes it much more foolproof.
This fixes https://github.com/yonaskolb/XcodeGen/issues/24 by now properly quoting string with `@` in them.

This also fixes #37 by escaping quotes and newlines within a string with `/`